### PR TITLE
Fix application crash if language was changed

### DIFF
--- a/src/ModularToolManager/ViewModels/MainWindowViewModel.cs
+++ b/src/ModularToolManager/ViewModels/MainWindowViewModel.cs
@@ -9,9 +9,8 @@ using ModularToolManager.Models.Messages;
 using ModularToolManager.Services.Settings;
 using ModularToolManager.Services.Ui;
 using ModularToolManagerModel.Services.IO;
-using System.Dynamic;
+using System;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
 
@@ -20,8 +19,12 @@ namespace ModularToolManager.ViewModels;
 /// <summary>
 /// Main view model
 /// </summary>
-public partial class MainWindowViewModel : ObservableObject
+public partial class MainWindowViewModel : ObservableObject, IDisposable
 {
+    /// <summary>
+    /// Is the view already disposed
+    /// </summary>
+    private bool isDisposed;
 
     /// <summary>
     /// Service to use for locating view models
@@ -310,5 +313,28 @@ public partial class MainWindowViewModel : ObservableObject
         {
             await windowManagementService.ShowModalWindowAsync(modalWindowData, windowManagementService?.GetMainWindow());
         }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (isDisposed)
+        {
+            return;
+        }
+        WeakReferenceMessenger.Default.UnregisterAll(this);
+        if (MainContentModel is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+        isDisposed = true;
+    }
+
+    /// <summary>
+    /// Deconstructor to ensure dispose
+    /// </summary>
+    ~MainWindowViewModel()
+    {
+        Dispose();
     }
 }

--- a/src/ModularToolManager/Views/MainWindow.axaml.cs
+++ b/src/ModularToolManager/Views/MainWindow.axaml.cs
@@ -131,6 +131,10 @@ public partial class MainWindow : Window, IDisposable
             return;
         }
         WeakReferenceMessenger.Default.UnregisterAll(this);
+        if (DataContext is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
         isDisposed = true;
     }
 


### PR DESCRIPTION
Unregister from messager if not used anymore

# Description

- Fix crash if language was changed
- Add code to dispose view models correctly
- Fixes #99

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Check the steps providet in ticket [99]

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

[99]: https://github.com/XanatosX/ModularToolManager/issues/99